### PR TITLE
fix: Highilighting menu items with gatsby --prefix-path support

### DIFF
--- a/packages/gatsby-theme-fast-ai-sidebar/src/components/Navigation/Navigation.js
+++ b/packages/gatsby-theme-fast-ai-sidebar/src/components/Navigation/Navigation.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Flex, Hamburger } from '@fast-ai/ui-components';
+import { withPrefix } from 'gatsby';
 
 import { links } from '../../links';
 import Logo from '../Logo';
@@ -26,7 +27,7 @@ const Navigation = ({ fullWidth, nav, menu, setMenu }) => (
 			>
 				{links.map(({ label, to }) => (
 					<MenuItem key={to} textAlign={{ _: 'center', md: 'left' }} sx={{ minWidth: 'auto' }}>
-						<Match path={`${to}/*`}>
+						<Match path={`${withPrefix(to)}/*`}>
 							{({ match }) => (
 								<Link
 									variant="nav"

--- a/packages/gatsby-theme-fast-ai-sidebar/src/components/Sidebar.js
+++ b/packages/gatsby-theme-fast-ai-sidebar/src/components/Sidebar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import PropTypes from 'prop-types';
 import { Box } from '@fast-ai/ui-components';
 import { map } from 'ramda';
@@ -11,7 +12,7 @@ const getList = (links) =>
 		<ul>
 			{map(({ label, to, children }) => (
 				<li key={to}>
-					<Match path={`${to}`}>
+					<Match path={`${withPrefix(to)}`}>
 						{({ match }) => (
 							<Link
 								to={to}


### PR DESCRIPTION
Menu items were not highlighted when the site used the a [`path prefix`](https://www.gatsbyjs.org/docs/path-prefix/)