### PR TITLE
GatsbyCssBaseline

### DIFF
--- a/packages/gatsby-theme-fast-ai-sidebar/src/components/GatsbyCssBaseline.js
+++ b/packages/gatsby-theme-fast-ai-sidebar/src/components/GatsbyCssBaseline.js
@@ -1,14 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { CssBaseline } from '@fast-ai/ui-components';
 
-const GatsbyCssBaseline = () => (
+const GatsbyCssBaseline = ({ styles = '', ...rest }) => (
 	<CssBaseline
 		styles={`
-			#___gatsby, div[role="group"][tabindex] {
+			#___gatsby, #gatsby-focus-wrapper, div[role="group"][tabindex] {
 			    min-height: 100%;
+					height: 100%;
 			}
+			${styles}
 			`}
+		{...rest}
 	/>
 );
+
+GatsbyCssBaseline.propTypes = {
+	styles: PropTypes.string,
+};
 
 export default GatsbyCssBaseline;

--- a/packages/gatsby-theme-fast-ai/src/components/GatsbyCssBaseline.js
+++ b/packages/gatsby-theme-fast-ai/src/components/GatsbyCssBaseline.js
@@ -1,14 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { CssBaseline } from '@fast-ai/ui-components';
 
-const GatsbyCssBaseline = () => (
+const GatsbyCssBaseline = ({ styles = '', ...rest }) => (
 	<CssBaseline
 		styles={`
-			#___gatsby, div[role="group"][tabindex] {
+			#___gatsby, #gatsby-focus-wrapper, div[role="group"][tabindex] {
 			    min-height: 100%;
+					height: 100%;
 			}
+			${styles}
 			`}
+		{...rest}
 	/>
 );
+
+GatsbyCssBaseline.propTypes = {
+	styles: PropTypes.string,
+};
 
 export default GatsbyCssBaseline;


### PR DESCRIPTION
Some layouts are dependent of 100% height of html and body elements.
Gatsbys adds its own wrapper element which the height do not have set.
The PR fixes it nicely in the theme.